### PR TITLE
Always add jfrog CLI to PATH

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -19,6 +19,7 @@ export class Utils {
         let fileName: string = Utils.getCliExecutableName();
         let cliDir: string = toolCache.find(fileName, version);
         if (cliDir) {
+            core.addPath(cliDir);
             return path.join(cliDir, fileName);
         }
         let url: string = Utils.getCliUrl(version, fileName);


### PR DESCRIPTION
Just playing around with this action on a self hosted runner, it seems like the action succeeds the first time it is executed on a host, but fails every subsequent time. I think it is because the action only calls `core.addPath` if it actively downloaded the JFrog CLI, instead of every time the action is executed.